### PR TITLE
Make the startup file portable

### DIFF
--- a/pyBar
+++ b/pyBar
@@ -6,5 +6,5 @@ BASEDIR=${BASEDIR%/*}
 
 
 cd $BASEDIR
-/usr/bin/python $BASEDIR/pyBar.py
+/usr/bin/env python2 $BASEDIR/pyBar.py
 cd -


### PR DESCRIPTION
Sur certaines distributions Linux comme Archlinux, la commande `python` est affectée à Python 3. Comme pyBar utilise Python 2, le script de lancement générera une erreur. La méthode conseillée pour les scripts python est d’utiliser `/usr/bin/env pythonX` où `X` est la version de Python voulue.
